### PR TITLE
Docs: Add instructions for running with uvx

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ just dev-setup  # Install in development mode
 
 ### From GitHub (Direct Use)
 
+### Using uvx (Recommended for macOS)
+
+You can also run this tool directly from GitHub without a manual clone or installation using `uvx`. `uvx` is a command-line tool that executes Python applications from various sources, including GitHub repositories, automatically managing virtual environments.
+
+Make sure you have `uvx` installed. If not, you can install it via pip:
+```sh
+pip install uvx
+```
+
+Then, run `about-this-mac` using:
+```sh
+uvx github_username/about-this-mac
+```
+Replace `github_username/about-this-mac` with the actual repository path.
+This will download the necessary files to a temporary environment and run the application. You can pass command-line arguments as usual:
+```sh
+uvx github_username/about-this-mac --format markdown --output report.md
+```
+
 You can install directly from GitHub:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ just dev-setup  # Install in development mode
 
 ### From GitHub (Direct Use)
 
-### Using uvx (Recommended for macOS)
+#### Using uvx (Recommended for macOS)
 
 You can also run this tool directly from GitHub without a manual clone or installation using `uvx`. `uvx` is a command-line tool that executes Python applications from various sources, including GitHub repositories, automatically managing virtual environments.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can also run this tool directly from GitHub without a manual clone or instal
 
 Make sure you have `uvx` installed. If not, you can install it via pip:
 ```sh
-pip install uvx
+python3 -m pip install uvx
 ```
 
 Then, run `about-this-mac` using:


### PR DESCRIPTION
Explain how to use uvx to run the CLI tool directly from GitHub on macOS, providing installation instructions for uvx and example usage. This offers a convenient way for you to use the tool without manual cloning or global installation.